### PR TITLE
Added support for DB-API 2.0 compatibility, missing set_trace_callback proxy

### DIFF
--- a/.pylint
+++ b/.pylint
@@ -527,7 +527,7 @@ max-locals=15
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=21
 
 # Maximum number of return / yield for function / method body
 max-returns=6

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -49,7 +49,8 @@ class Cursor:
         await self._execute(self._cursor.execute, sql, parameters)
         return self
 
-    async def executemany(self, sql: str, parameters: Iterable[Iterable[Any]]) -> "Cursor":
+    async def executemany(self, sql: str,
+                          parameters: Iterable[Iterable[Any]]) -> "Cursor":
         """Execute the given multiquery."""
         await self._execute(self._cursor.executemany, sql, parameters)
         return self

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -47,14 +47,17 @@ class Cursor:
         if parameters is None:
             parameters = []
         await self._execute(self._cursor.execute, sql, parameters)
+        return self
 
     async def executemany(self, sql: str, parameters: Iterable[Iterable[Any]]) -> None:
         """Execute the given multiquery."""
         await self._execute(self._cursor.executemany, sql, parameters)
+        return self
 
     async def executescript(self, sql_script: str) -> None:
         """Execute a user script."""
         await self._execute(self._cursor.executescript, sql_script)
+        return self
 
     async def fetchone(self) -> Optional[sqlite3.Row]:
         """Fetch a single row."""
@@ -293,6 +296,11 @@ class Connection(Thread):
         self, handler: Callable[[], Optional[int]], n: int
     ) -> None:
         await self._execute(self._conn.set_progress_handler, handler, n)
+
+    async def set_trace_callback(
+        self, handler: Callable
+    ) -> None:
+        await self._execute(self._conn.set_trace_callback, handler)
 
 
 def connect(

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -42,19 +42,19 @@ class Cursor:
         """Execute the given function on the shared connection's thread."""
         return await self._conn._execute(fn, *args, **kwargs)
 
-    async def execute(self, sql: str, parameters: Iterable[Any] = None) -> None:
+    async def execute(self, sql: str, parameters: Iterable[Any] = None) -> "Cursor":
         """Execute the given query."""
         if parameters is None:
             parameters = []
         await self._execute(self._cursor.execute, sql, parameters)
         return self
 
-    async def executemany(self, sql: str, parameters: Iterable[Iterable[Any]]) -> None:
+    async def executemany(self, sql: str, parameters: Iterable[Iterable[Any]]) -> "Cursor":
         """Execute the given multiquery."""
         await self._execute(self._cursor.executemany, sql, parameters)
         return self
 
-    async def executescript(self, sql_script: str) -> None:
+    async def executescript(self, sql_script: str) -> "Cursor":
         """Execute a user script."""
         await self._execute(self._cursor.executescript, sql_script)
         return self


### PR DESCRIPTION
### Description

First, thank you to John and the other contributors for this library. It is tight and well written and easy to use.

1. Added support to Cursor to return self to ensure compatibility with DB-API 2.0 reliant code. This style uses cursors as the main point of execution control vs. the connection. Retrofitting aiosqlite into that style of code wasn't possible without this support.

2. Added set_trace_callback proxy support which was missing.

Note: We did not add additional tests for Cursor support. The existing tests are unaffected. This code is deployed in our production environment already. An additional test for set_trace_callback was also not added. Apologies for running out of time for these but we do know the code works.

Fixes: #60, #61
