### PR TITLE
Add type annotations for the contextmanager decorator

### DIFF
--- a/aiosqlite/context.py
+++ b/aiosqlite/context.py
@@ -4,16 +4,12 @@
 
 import collections.abc
 from functools import wraps
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    TypeVar
-)
+from typing import Any, Callable, Coroutine, TypeVar
 
 from typing_extensions import AsyncContextManager
 
-_T = TypeVar('_T')
+_T = TypeVar("_T")
+
 
 class ContextManager(collections.abc.Coroutine):
     __slots__ = ("_coro", "_obj")

--- a/aiosqlite/context.py
+++ b/aiosqlite/context.py
@@ -2,11 +2,20 @@
 # Licensed under the MIT license
 
 
-from collections.abc import Coroutine
+import collections.abc
 from functools import wraps
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    TypeVar
+)
 
+from typing_extensions import AsyncContextManager
 
-class ContextManager(Coroutine):
+_T = TypeVar('_T')
+
+class ContextManager(collections.abc.Coroutine):
     __slots__ = ("_coro", "_obj")
 
     def __init__(self, coro):
@@ -40,7 +49,9 @@ class ContextManager(Coroutine):
         self._obj = None
 
 
-def contextmanager(method):
+def contextmanager(
+    method: Callable[..., Coroutine[Any, Any, _T]]
+) -> Callable[..., AsyncContextManager[_T]]:
     @wraps(method)
     def wrapper(self, *args, **kwargs) -> ContextManager:
         return ContextManager(method(self, *args, **kwargs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.rst"
 home-page = "https://aiosqlite.omnilib.dev"
-requires = []
+requires = ["typing_extensions"]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### Description

Adding type annotations to the `contextmanager` decorator helps type checkers to catch more errors. For example, this code doesn't generate any error with `mypy`:
```python
import aiosqlite

async def foo(db_path: str, sql: str):
    async with aiosqlite.connect(db_path) as db:
        async with db.execute(sql) as cursor:
            print(await cursor.fetchal())
```
While with this pull request `mypy` generate the following error:

> error: "Cursor" has no attribute "fetchal"; maybe "fetchall"?