### PR TITLE
Remove print statements used for debugging

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -385,10 +385,8 @@ class Connection(Thread):
         if sys.version_info < (3, 7):
             raise RuntimeError("backup() method is only available on Python 3.7+")
 
-        print("here")
         if isinstance(target, Connection):
             target = target._conn
-        print("there")
 
         await self._execute(
             self._conn.backup,


### PR DESCRIPTION
### Description
I removed a couple of print statements that were left in the new `backup` feature

