### PR TITLE
Lower log severity for "returning exception"

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -96,7 +96,7 @@ class Connection(Thread):
                 LOG.debug("returning %s", result)
                 get_loop(future).call_soon_threadsafe(future.set_result, result)
             except BaseException as e:
-                LOG.exception("returning exception %s", e)
+                LOG.info("returning exception %s", e)
                 get_loop(future).call_soon_threadsafe(future.set_exception, e)
 
     async def _execute(self, fn, *args, **kwargs):


### PR DESCRIPTION
The exception level should be used for errors that can't be neither
handled or propagated, but in this case the error is correctly passed
to the user's code which they can handle just fine (without the need
to unconditionally spam the console with logs).

Closes #75.