### PR TITLE
Allow caller to handle close() exception, reduce logger to "info"

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -149,9 +149,11 @@ class Connection(Thread):
         try:
             await self._execute(self._conn.close)
         except Exception:
-            LOG.exception("exception occurred while closing connection")
-        self._running = False
-        self._connection = None
+            LOG.info("exception occurred while closing connection")
+            raise
+        finally:
+            self._running = False
+            self._connection = None
 
     @contextmanager
     async def execute(self, sql: str, parameters: Iterable[Any] = None) -> Cursor:


### PR DESCRIPTION
### Description

Allow callers to handle exceptions raised from `close()`.   

Fixes: #68 (maybe, I'm not sure where the integrity error based on the bug report)

My use-case is for dealing with `interrupt`, in which a `sqlite.OperationalError: interrupted` will always be logged in `Connection.close()`:

```
    async def close(self) -> None:
        """Complete queued queries/cursors and close the connection."""
        try:
            await self._execute(self._conn.close)
        except Exception:
            LOG.exception("exception occurred while closing connection")
        self._running = False
        self._connection = None
```

My PR changes this so that 
a) the exception is re-raised, so that callers can suppress it, which is necessary to make a clean shutdown, e.g. for microservices, and
b) the logging severity is reduced to make it informational rather than exceptional (since callers can choose to log it at error level), similar to what was done in #76 

```
    async def close(self) -> None:
        """Complete queued queries/cursors and close the connection."""
        try:
            await self._execute(self._conn.close)
        except Exception:
            LOG.info("exception occurred while closing connection")
            raise
        finally:
            self._running = False
            self._connection = None

```