### PR TITLE
Lower log severity for "returning exception" to debug level

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -104,7 +104,7 @@ class Connection(Thread):
 
                 get_loop(future).call_soon_threadsafe(set_result, future, result)
             except BaseException as e:
-                LOG.info("returning exception %s", e)
+                LOG.debug("returning exception %s", e)
 
                 def set_exception(fut, e):
                     if not fut.done():


### PR DESCRIPTION
I just want to say that all the points raised in https://github.com/omnilib/aiosqlite/pull/76 are absolutely valid, but it also means that https://github.com/omnilib/aiosqlite/blob/4a5f179c84f1b32f4944e893e1b0a34eabb7fe38/aiosqlite/core.py#L107 should be logging at the debug level. I mean, if https://github.com/omnilib/aiosqlite/blob/4a5f179c84f1b32f4944e893e1b0a34eabb7fe38/aiosqlite/core.py#L97-L99 log at the debug level, then exception returned from `sqlite` should also be logged at the debug level. In other words, let it bubble up and user application should either log it or throw it. And if a user have doubts whether the exception is caused by `sqlite` or `aiosqlite` then he could enable debug level and confirm that.