### PR TITLE
Support subclassing Connection

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -376,6 +376,7 @@ def connect(
     *,
     iter_chunk_size=64,
     loop: Optional[asyncio.AbstractEventLoop] = None,
+    cls: Type[Connection] = Connection,
     **kwargs: Any
 ) -> Connection:
     """Create and return a connection proxy to the sqlite database."""
@@ -396,4 +397,4 @@ def connect(
 
         return sqlite3.connect(loc, **kwargs)
 
-    return Connection(connector, iter_chunk_size)
+    return cls(connector, iter_chunk_size)


### PR DESCRIPTION
### Description

Add `cls` kwarg to `core.connect` that is a subclass or Connection (or a `Callable[[Callable[[Any], sqlite3.Connection], int], Connection]`) (default: `Connection`)

Example usage:
```py
class MyConnection(aiosqlite.Connection):
    ...

async def main():
    conn = await aiosqlite.connect(':memory:', cls=MyConnection)
    # use methods and attrs of MyConnection
```

Current workaround: `connect` must be redefined to explicitly call your custom async connection factory.