### PR TITLE
Replace aiounittest starting py38

### DIFF
--- a/aiosqlite/tests/perf.py
+++ b/aiosqlite/tests/perf.py
@@ -5,9 +5,13 @@
 Simple perf tests for aiosqlite and the asyncio run loop.
 """
 import string
+import sys
 import time
 
-import aiounittest
+if sys.version_info < (3, 8):
+    from aiounittest import AsyncTestCase as TestCase
+else:
+    from unittest import IsolatedAsyncioTestCase as TestCase
 
 import aiosqlite
 from .smoke import setup_logger
@@ -60,7 +64,7 @@ def timed(fn, name=None):
     return wrapper
 
 
-class PerfTest(aiounittest.AsyncTestCase):
+class PerfTest(TestCase):
     @classmethod
     def setUpClass(cls):
         print(f"Running perf tests for at least {TARGET:.1f}s each...")

--- a/aiosqlite/tests/smoke.py
+++ b/aiosqlite/tests/smoke.py
@@ -8,7 +8,10 @@ from sqlite3 import OperationalError
 from threading import Thread
 from unittest import SkipTest, skipIf, skipUnless
 
-import aiounittest
+if sys.version_info < (3, 8):
+    from aiounittest import AsyncTestCase as TestCase
+else:
+    from unittest import IsolatedAsyncioTestCase as TestCase
 
 import aiosqlite
 from .helpers import setup_logger
@@ -22,7 +25,7 @@ except ImportError:
     default_text_factory = str
 
 
-class SmokeTest(aiounittest.AsyncTestCase):
+class SmokeTest(TestCase):
     @classmethod
     def setUpClass(cls):
         setup_logger()


### PR DESCRIPTION
Hi,

I think we could replace the aiounittest dependency with the standard library for newer Python.

This would allow easy automatic testing of the Debian package.

Any thoughts?