### PR TITLE
test_memory_db_clears

### DIFF
--- a/aiosqlite/tests/smoke.py
+++ b/aiosqlite/tests/smoke.py
@@ -432,10 +432,10 @@ class SmokeTest(aiounittest.AsyncTestCase):
         # the entire db should be removed so foo should not be present below
         async with aiosqlite.connect(url) as db2:
             async with db2.execute(
-               """
-               select name from sqlite_master
-               where type ='table' and name not like 'sqlite_%'
-               """
+                """
+                select name from sqlite_master
+                where type ='table' and name not like 'sqlite_%'
+                """
             ) as cursor:
                 rows = await cursor.fetchall()
 


### PR DESCRIPTION
### Description

Closing a URL-defined memory DB connection only erases it in Linux.  On Windows and macOS the contents persists into subsequent connections.

https://www.sqlite.org/inmemorydb.html
> The database is automatically deleted and memory is reclaimed when the last connection to the database closes.

Fixes: #

Draft for:
- [ ] Debugging
- [ ] Implementing a fix
- [ ] Test against bare `:memory:` as well