### PR TITLE
Update type hint for `isolation_level` property.

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -20,6 +20,7 @@ from typing import (
     Callable,
     Generator,
     Iterable,
+    Literal,
     Optional,
     Type,
     Union,

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -20,12 +20,16 @@ from typing import (
     Callable,
     Generator,
     Iterable,
-    Literal,
     Optional,
     Type,
     Union,
 )
 from warnings import warn
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 from .context import contextmanager
 from .cursor import Cursor

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -258,11 +258,11 @@ class Connection(Thread):
         return self._conn.in_transaction
 
     @property
-    def isolation_level(self) -> str:
+    def isolation_level(self) -> Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]:
         return self._conn.isolation_level
 
     @isolation_level.setter
-    def isolation_level(self, value: str) -> None:
+    def isolation_level(self, value: Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]) -> None:
         self._conn.isolation_level = value
 
     @property

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -20,7 +20,6 @@ from typing import (
     Callable,
     Generator,
     Iterable,
-    Literal,
     Optional,
     Type,
     Union,
@@ -259,11 +258,11 @@ class Connection(Thread):
         return self._conn.in_transaction
 
     @property
-    def isolation_level(self) -> Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]:
+    def isolation_level(self) -> Optional[str]:
         return self._conn.isolation_level
 
     @isolation_level.setter
-    def isolation_level(self, value: Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]) -> None:
+    def isolation_level(self, value: Optional[str]) -> None:
         self._conn.isolation_level = value
 
     @property

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -20,6 +20,7 @@ from typing import (
     Callable,
     Generator,
     Iterable,
+    Literal,
     Optional,
     Type,
     Union,
@@ -32,6 +33,9 @@ from .cursor import Cursor
 __all__ = ["connect", "Connection", "Cursor"]
 
 LOG = logging.getLogger("aiosqlite")
+
+
+IsolationLevel = Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]
 
 
 def get_loop(future: asyncio.Future) -> asyncio.AbstractEventLoop:
@@ -258,11 +262,11 @@ class Connection(Thread):
         return self._conn.in_transaction
 
     @property
-    def isolation_level(self) -> Optional[str]:
+    def isolation_level(self) -> IsolationLevel:
         return self._conn.isolation_level
 
     @isolation_level.setter
-    def isolation_level(self, value: Optional[str]) -> None:
+    def isolation_level(self, value: IsolationLevel) -> None:
         self._conn.isolation_level = value
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.rst"
 home-page = "https://aiosqlite.omnilib.dev"
-requires = []
+requires = [
+    "typing_extensions >= 4.0; python_version < '3.11'",
+]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "john@noswap.com"
 description-file = "README.rst"
 home-page = "https://aiosqlite.omnilib.dev"
 requires = [
-    "typing_extensions >= 4.0; python_version < '3.11'",
+    "typing_extensions >= 4.0; python_version < '3.8'",
 ]
 requires-python = ">=3.6"
 classifiers = [


### PR DESCRIPTION
Hi! I was developing an app using `aiosqlite` and `mypy v0.950` reported that I could't set `isolation_level` to None. 
I updated the type hint based on the documentation for the standard sqlite3 python module.
https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.isolation_level

Optional[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"]]


