### PR TITLE
Created a connected property

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -135,7 +135,12 @@ class Connection(Thread):
         self._tx.put_nowait((future, function))
 
         return await future
-
+    
+    @property
+    def is_connected(self) -> bool:
+        """Returns if a Connection to a sqlite database was established."""
+        return self._connection is not None
+    
     async def _connect(self) -> "Connection":
         """Connect to the actual sqlite database."""
         if self._connection is None:


### PR DESCRIPTION
I think this should exist since you're required to asynchronously connect the database which results in the possibility of trying to execute sql before a connection could be established

### Description

A property returning a Boolean if a sqlite connection was established

Fixes: #
