### PR TITLE
Better type hint for Connection.text_factory

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -282,11 +282,11 @@ class Connection(Thread):
         self._conn.row_factory = factory
 
     @property
-    def text_factory(self) -> Type:
+    def text_factory(self) -> Callable[[bytes], Any]:
         return self._conn.text_factory
 
     @text_factory.setter
-    def text_factory(self, factory: Type) -> None:
+    def text_factory(self, factory: Callable[[bytes], Any]) -> None:
         self._conn.text_factory = factory
 
     @property


### PR DESCRIPTION
text_factory type hint was simply "Type" which is kinda right for the
most common cases of the parameter (str and bytes).

However, text_fatory can be any other callable that accepts a bytes
parameter and returns the resulting object as described in the docs for
sqlite3 python standard module.
(ref: https://docs.python.org/3/library/sqlite3.html )

In particular this fix is for support another common enough idiom,
which is setting

`conn.text_factory = lambda b: b.decode(errors=ignore)`
