### PR TITLE
Add paramstyle to aiosqlite

### DIFF
--- a/aiosqlite/__init__.py
+++ b/aiosqlite/__init__.py
@@ -9,6 +9,7 @@ from sqlite3 import (  # pylint: disable=redefined-builtin
     IntegrityError,
     NotSupportedError,
     OperationalError,
+    paramstyle
     ProgrammingError,
     register_adapter,
     register_converter,
@@ -24,6 +25,7 @@ from .core import connect, Connection, Cursor
 
 __all__ = [
     "__version__",
+    "paramstyle",
     "register_adapter",
     "register_converter",
     "sqlite_version",

--- a/aiosqlite/__init__.py
+++ b/aiosqlite/__init__.py
@@ -9,7 +9,7 @@ from sqlite3 import (  # pylint: disable=redefined-builtin
     IntegrityError,
     NotSupportedError,
     OperationalError,
-    paramstyle
+    paramstyle,
     ProgrammingError,
     register_adapter,
     register_converter,


### PR DESCRIPTION
Many other SQL modules have paramstyle, which indicates how you should format untrusted data For example sqlite3's paramstyle is `qmark`, MS SQL Server's style is `pyformat`, and MySQL's style is `format`

### Description

New feature: paramstyle
