### PR TITLE
Add row_factory property to Cursor

### DIFF
--- a/aiosqlite/cursor.py
+++ b/aiosqlite/cursor.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license
 
 import sqlite3
-from typing import Any, AsyncIterator, Iterable, Optional, Tuple, TYPE_CHECKING
+from typing import Any, AsyncIterator, Iterable, Optional, Tuple, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .core import Connection
@@ -87,6 +87,14 @@ class Cursor:
     @property
     def description(self) -> Tuple[Tuple]:
         return self._cursor.description
+
+    @property
+    def row_factory(self) -> Optional[Type]:
+        return self._cursor.row_factory
+
+    @row_factory.setter
+    def row_factory(self, factory: Optional[Type]) -> None:
+        self._cursor.row_factory = factory
 
     @property
     def connection(self) -> sqlite3.Connection:

--- a/aiosqlite/tests/smoke.py
+++ b/aiosqlite/tests/smoke.py
@@ -242,6 +242,17 @@ class SmokeTest(TestCase):
                 with self.assertRaises(TypeError):
                     _ = row["k"]
 
+            async with db.cursor() as cursor:
+                cursor.row_factory = aiosqlite.Row
+                self.assertEqual(cursor.row_factory, aiosqlite.Row)
+                await cursor.execute("select * from test_properties")
+                row = await cursor.fetchone()
+                self.assertIsInstance(row, aiosqlite.Row)
+                self.assertEqual(row[1], 1)
+                self.assertEqual(row[2], "hi")
+                self.assertEqual(row["k"], 1)
+                self.assertEqual(row["d"], "hi")
+
             db.row_factory = aiosqlite.Row
             db.text_factory = bytes
             self.assertEqual(db.row_factory, aiosqlite.Row)


### PR DESCRIPTION
### Description

Adds the row_factory property to the Cursor class as documented here: https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.row_factory
Also amended the unit tests to cover this new case.

Fixes: https://github.com/omnilib/aiosqlite/issues/180
