### PR TITLE
make .close() method idempotent

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -159,6 +159,10 @@ class Connection(Thread):
 
     async def close(self) -> None:
         """Complete queued queries/cursors and close the connection."""
+
+        if self._connection is None:
+            return
+
         try:
             await self._execute(self._conn.close)
         except Exception:

--- a/aiosqlite/tests/smoke.py
+++ b/aiosqlite/tests/smoke.py
@@ -404,6 +404,14 @@ class SmokeTest(TestCase):
             except sqlite3.ProgrammingError:
                 pass
 
+    async def test_close_twice(self):
+        db = await aiosqlite.connect(TEST_DB)
+
+        await db.close()
+
+        # no error
+        await db.close()
+
     async def test_backup_aiosqlite(self):
         def progress(a, b, c):
             print(a, b, c)


### PR DESCRIPTION
While not explicitly documented in pep-249, repeated calls to connection.close() are customarily accepted without error; the sqlite3 module itself allows multiple calls to .close() as do popular asyncio database drivers such as asyncpg.

Prior to this change, the .close() method would attempt to execute a command within the thread, however since the _connection attribute is None, it would raise ValueError("no active connection"). This ValueError is also not pep-249 compliant since all exceptions raised should be subclasses of dbapi.Error, so if the aiosqlite project would prefer repeated .close() calls raise, it should raise within the dbapi.Error hierarchy.

The change here is submitted by the maintainers of SQLAlchemy (https://www.sqlalchemy.org) for the benefit of projects to reduce warnings emitted during various connection, application, and interpreter shutdown scenarios.

following the [Contributor guide](https://github.com/omnilib/aiosqlite/blob/main/CONTRIBUTING.md) I did not see specifics on how to add changelog entries and no issue number was required.