### PR TITLE
fix error for cursor.connection(return not async connection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 
 # Editors
 .vscode/
+.idea/

--- a/aiosqlite/cursor.py
+++ b/aiosqlite/cursor.py
@@ -108,8 +108,8 @@ class Cursor:
         self._cursor.row_factory = factory
 
     @property
-    def connection(self) -> sqlite3.Connection:
-        return self._cursor.connection
+    def connection(self) -> "Connection":
+        return self._conn
 
     async def __aenter__(self):
         return self


### PR DESCRIPTION
```text
await cur.connection.commit()
          ^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 126329731884608 and this is thread id 126329755602944.
```

### Description

method connection for cursor return not async connection

Fixes: # replace on async connection ___self._conn___
