### PR TITLE
Add `daemonic` option

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -58,8 +58,9 @@ class Connection(Thread):
         connector: Callable[[], sqlite3.Connection],
         iter_chunk_size: int,
         loop: Optional[asyncio.AbstractEventLoop] = None,
+        daemonic: bool = False,
     ) -> None:
-        super().__init__()
+        super().__init__(daemon=daemonic)
         self._running = True
         self._connection: Optional[sqlite3.Connection] = None
         self._connector = connector
@@ -371,6 +372,7 @@ def connect(
     *,
     iter_chunk_size=64,
     loop: Optional[asyncio.AbstractEventLoop] = None,
+    daemonic: bool = False,
     **kwargs: Any,
 ) -> Connection:
     """Create and return a connection proxy to the sqlite database."""
@@ -391,4 +393,4 @@ def connect(
 
         return sqlite3.connect(loc, **kwargs)
 
-    return Connection(connector, iter_chunk_size)
+    return Connection(connector, iter_chunk_size, daemonic)


### PR DESCRIPTION
### Description

Normally, the Connection thread prevents program exit unless close() is explicitly called. This is no longer the case if the new `deaemonic` option is set to `True`.

It defaults to `False` which means aiosqlite's behaviour remains unaffected unless explicitly configured.

This PR would also address issues which have been opened for some time now.

Fixes: https://github.com/omnilib/aiosqlite/issues/74, https://github.com/omnilib/aiosqlite/issues/299
