### PR TITLE
Add proxy for autocommit property on Connection

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -252,6 +252,10 @@ class Connection(Thread):
         )
 
     @property
+    def autocommit(self) -> int:
+        return self._conn.autocommit
+
+    @property
     def in_transaction(self) -> bool:
         return self._conn.in_transaction
 


### PR DESCRIPTION
### Description

Add a proxy property for the `autocommit` property on `sqlite3.Connection` objects.

### Use Case

I want `autocommit=False` as suggested by the `sqlite3` docs (see [docs](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.autocommit)). I also want to set `PRAGMA journal_mode = WAL`. The issue is that I can't change the `journal_mode` when in a transaction, which is always the case when `autocommit=False`. So the solution is to set the `autocommit` property after setting the `journal_mode`. This works fine in `sqlite3`, but `aiosqlite` doesn't have the property.

I can work around this by simply reaching into the `aiosqlite.Connection` object and accessing the `_conn` attribute, but this is clearly not ideal.