### PR TITLE
Drop Python 3.8, set Python3.9 as the minimum version.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Preparation
 
-You'll need to have at least Python 3.8 available for testing.
+You'll need to have at least Python 3.9 available for testing.
 
 You can do this with [pyenv][]:
 

--- a/aiosqlite/context.py
+++ b/aiosqlite/context.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT license
 
 
+from collections.abc import Coroutine, Generator
 from functools import wraps
-from typing import Any, AsyncContextManager, Callable, Coroutine, Generator, TypeVar
+from typing import Any, AsyncContextManager, Callable, TypeVar
 
 from .cursor import Cursor
 

--- a/aiosqlite/context.py
+++ b/aiosqlite/context.py
@@ -3,15 +3,16 @@
 
 
 from collections.abc import Coroutine, Generator
+from contextlib import AbstractAsyncContextManager
 from functools import wraps
-from typing import Any, AsyncContextManager, Callable, TypeVar
+from typing import Any, Callable, TypeVar
 
 from .cursor import Cursor
 
 _T = TypeVar("_T")
 
 
-class Result(AsyncContextManager[_T], Coroutine[Any, Any, _T]):
+class Result(AbstractAsyncContextManager[_T], Coroutine[Any, Any, _T]):
     __slots__ = ("_coro", "_obj")
 
     def __init__(self, coro: Coroutine[Any, Any, _T]):

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -8,20 +8,16 @@ Core implementation of aiosqlite proxies
 import asyncio
 import logging
 import sqlite3
+from collections.abc import AsyncIterator, Generator, Iterable
 from functools import partial
 from pathlib import Path
 from queue import Empty, Queue, SimpleQueue
 from threading import Thread
 from typing import (
     Any,
-    AsyncIterator,
     Callable,
-    Generator,
-    Iterable,
     Literal,
     Optional,
-    Tuple,
-    Type,
     Union,
 )
 from warnings import warn
@@ -63,7 +59,7 @@ class Connection(Thread):
         self._running = True
         self._connection: Optional[sqlite3.Connection] = None
         self._connector = connector
-        self._tx: SimpleQueue[Tuple[asyncio.Future, Callable[[], Any]]] = SimpleQueue()
+        self._tx: SimpleQueue[tuple[asyncio.Future, Callable[[], Any]]] = SimpleQueue()
         self._iter_chunk_size = iter_chunk_size
 
         if loop is not None:
@@ -264,11 +260,11 @@ class Connection(Thread):
         self._conn.isolation_level = value
 
     @property
-    def row_factory(self) -> Optional[Type]:
+    def row_factory(self) -> Optional[type]:
         return self._conn.row_factory
 
     @row_factory.setter
-    def row_factory(self, factory: Optional[Type]) -> None:
+    def row_factory(self, factory: Optional[type]) -> None:
         self._conn.row_factory = factory
 
     @property

--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -13,13 +13,7 @@ from functools import partial
 from pathlib import Path
 from queue import Empty, Queue, SimpleQueue
 from threading import Thread
-from typing import (
-    Any,
-    Callable,
-    Literal,
-    Optional,
-    Union,
-)
+from typing import Any, Callable, Literal, Optional, Union
 from warnings import warn
 
 from .context import contextmanager

--- a/aiosqlite/cursor.py
+++ b/aiosqlite/cursor.py
@@ -2,14 +2,11 @@
 # Licensed under the MIT license
 
 import sqlite3
+from collections.abc import AsyncIterator, Iterable
 from typing import (
     Any,
-    AsyncIterator,
     Callable,
-    Iterable,
     Optional,
-    Tuple,
-    Type,
     TYPE_CHECKING,
 )
 
@@ -66,7 +63,7 @@ class Cursor:
 
     async def fetchmany(self, size: Optional[int] = None) -> Iterable[sqlite3.Row]:
         """Fetch up to `cursor.arraysize` number of rows."""
-        args: Tuple[int, ...] = ()
+        args: tuple[int, ...] = ()
         if size is not None:
             args = (size,)
         return await self._execute(self._cursor.fetchmany, *args)
@@ -96,7 +93,7 @@ class Cursor:
         self._cursor.arraysize = value
 
     @property
-    def description(self) -> Tuple[Tuple[str, None, None, None, None, None, None], ...]:
+    def description(self) -> tuple[tuple[str, None, None, None, None, None, None], ...]:
         return self._cursor.description
 
     @property
@@ -104,7 +101,7 @@ class Cursor:
         return self._cursor.row_factory
 
     @row_factory.setter
-    def row_factory(self, factory: Optional[Type]) -> None:
+    def row_factory(self, factory: Optional[type]) -> None:
         self._cursor.row_factory = factory
 
     @property

--- a/aiosqlite/cursor.py
+++ b/aiosqlite/cursor.py
@@ -3,12 +3,7 @@
 
 import sqlite3
 from collections.abc import AsyncIterator, Iterable
-from typing import (
-    Any,
-    Callable,
-    Optional,
-    TYPE_CHECKING,
-)
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .core import Connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ skip_covered = true
 
 [tool.mypy]
 ignore_missing_imports = true
+python_version = "3.9"
 
 [[tool.mypy.overrides]]
 module = "aiosqlite.tests.perf"


### PR DESCRIPTION
### Description

The Python 3.8 support is over, Python 3.9 is being maintained on security updates until the [31 Oct 2025](https://endoflife.date/python).

Solves the issue #314 .