### PR TITLE
fix: close connection thread properly if BaseException raised in connect step

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -138,7 +138,7 @@ class Connection(Thread):
                 future = asyncio.get_event_loop().create_future()
                 self._tx.put_nowait((future, self._connector))
                 self._connection = await future
-            except Exception:
+            except BaseException:
                 self._stop_running()
                 self._connection = None
                 raise


### PR DESCRIPTION
### Description

Since the `Connection._connect` method currently only catches `Exception` (and not `BaseException`), if one is raised, the connection thread won't be closed and the program will hang on exit.

Fixes: close connection thread properly if `BaseException` raised in connect step
