### PR TITLE
Allow specifying thread name for db connection

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -48,8 +48,9 @@ class Connection(Thread):
         connector: Callable[[], sqlite3.Connection],
         iter_chunk_size: int,
         loop: Optional[asyncio.AbstractEventLoop] = None,
+        thread_name: Optional[str] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(name=thread_name)
         self._running = True
         self._connection: Optional[sqlite3.Connection] = None
         self._connector = connector
@@ -361,6 +362,7 @@ def connect(
     *,
     iter_chunk_size=64,
     loop: Optional[asyncio.AbstractEventLoop] = None,
+    thread_name: Optional[str] = None,
     **kwargs: Any,
 ) -> Connection:
     """Create and return a connection proxy to the sqlite database."""
@@ -381,4 +383,4 @@ def connect(
 
         return sqlite3.connect(loc, **kwargs)
 
-    return Connection(connector, iter_chunk_size)
+    return Connection(connector, iter_chunk_size, loop, thread_name)


### PR DESCRIPTION
This PR introduces the ability to set a custom name for the internal thread used by aiosqlite.Connection. The new thread_name parameter is available in both aiosqlite.connect() and the Connection constructor. When specified, the thread will be started with the provided name, making it easier to identify in debuggers and profiling tools.

Example usage:
`
db = await aiosqlite.connect(..., thread_name="aiosqlite-thread")
`

This change is fully backward compatible; the thread_name parameter is optional and defaults to the previous behavior.

