### PR TITLE
Remove obsolete dependency on typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 requires-python = ">=3.9"
-dependencies = [
-    "typing_extensions >= 4.0",
-]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Fixes: 7b518ced2 ("Drop 3.7 compat (#230)")